### PR TITLE
Sequence input feedback enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The following functions are implemented in the plugin:
 - Sequence
     - Move Sequence Fader
     - Push Sequence Button
+    - Track Sequence Running Status
 - Master
     - Move Master Fader
     - [Move Master BPM Fader](#bpm-faders)
@@ -63,3 +64,38 @@ The BPM faders allow to send BPM values (beats per minute) to executors or maste
 
 GrandMA3 sequences do not know a beat grid and are therefore difficult to synchronize with Resolume, Ableton or CDJs without further tools. In this plugin there are the functions **Add Executor to SyncList** and **Sync Executors** to enable synchronization to beats.  
 **Add Executor to SyncList** Adds an executor to a list of executors to be synchronized. **Sync Executors** then restarts all executors on that list. Typically, Sync Executors is mapped to the beat signal, for example the **new Bar trigger** from Ableton Link. This way you can realize, for example, that dimmer phasers always have their maximum brightness on the kick.  On [freudundlight.de](https://freudundlight.de/Beat-Sync/) you can find an explanation of how you can use this function to realise a beat synchronisation between Pioneer CDJs and grandMA3.
+
+## Sequence Feedback from grandMA3
+
+When _OSC Input_ is configured and enabled, this plugin has the ability to read
+and track various parameters of sequences as they are acted upon in grandMA3.
+
+### Setup
+
+Ensure that _OSC Input_ parameter is enabled and that MA3 has an _In & Out_
+line configured for `Send` and `Send Command` to Chataigne's IP and _Local Port_.
+
+### Learning & Tracking
+
+This plugin can listen for commands and changes to MA3 sequences, allowing you
+to create actions, mappings, and other workflows when -- for example -- a sequence
+fires, stops, its master fader changes, etc.
+
+In order for Chataigne to know about sequences in your show and their various
+parameters, you first need to teach it. Switch on _Learn from oscInput_ in the
+plugin parameters and fire a sequence event, such as a _Go+_, _Temp_, _Flash_, etc.
+The plugin's _Values_ will now contain a _Sequences_ container with your sequence
+number and the command that you triggered (and any associated values).
+
+You only need to use _Learn from oscInput_ during this training phase. As long
+as _OSC Input_ is enabled and the plugin instance knows about your sequences,
+it will continue to receive and update whenever MA3 sends an OSC event.
+
+The plugin features a special parameter in each sequence's value container
+called _Running_. As long as the plugin has simply learned about the existence
+of a sequence, it will attempt to track and follow any changes from MA3 (e.g.
+_Go+_, _Temp_, _Flash_, _Black_, _Swop_, fader movements, and so on) -- regardless
+of whether those parameters were added in the learning phase. If the plugin
+believes your sequence is on/running, the _Running_ value will be `true`,
+and `false` when off/stopped. This can be especially useful in mapping sequences
+to status indicators.

--- a/grandMA3.js
+++ b/grandMA3.js
@@ -231,7 +231,7 @@ function selectPage(page) {
 function oscEvent(address, args) {
   var address_list = address.split(".");
 
-  if (address.indexOf("13.13.1.6") == 1) {
+  if (address.indexOf("14.14.1.6") == 1) {
     processSequence(address_list[address_list.length - 1], args);
   }
 }

--- a/grandMA3.js
+++ b/grandMA3.js
@@ -236,54 +236,265 @@ function oscEvent(address, args) {
   }
 }
 
-function processSequence(sequence, args) {
+// Helper function to parse and scale fader values
+function parseAndScaleFaderValue(valueString, range) {
+  var value = parseFloat(valueString);
+  return (value === value) ? value / range : valueString; // Check if not NaN
+}
+
+// Helper function to update sequence name with description
+function updateSequenceName(sequenceContainer, sequence, description) {
+  if (description) {
+    sequenceContainer.setName(sequence + " | " + description, sequence);
+  }
+}
+
+// Global tracker for sequence running-states
+var SequenceStateTracker = {
+  runningStates: {},
+  runningParams: {},
+  // Storage for created parameters to avoid timing issues
+  createdParameters: {},
+
+  getRunningState: function(sequence) {
+    return this.runningStates[sequence];
+  },
+
+  setRunningState: function(sequence, state) {
+    this.runningStates[sequence] = state;
+  },
+
+  getRunningParam: function(sequence) {
+    return this.runningParams[sequence];
+  },
+
+  setRunningParam: function(sequence, param) {
+    this.runningParams[sequence] = param;
+  },
+
+  getCreatedParameter: function(sequence, command) {
+    var paramKey = sequence + "_" + command;
+    return this.createdParameters[paramKey];
+  },
+
+  setCreatedParameter: function(sequence, command, param) {
+    var paramKey = sequence + "_" + command;
+    this.createdParameters[paramKey] = param;
+  }
+};
+
+// Command mappings that result in a running-state transition
+var PERMANENT_COMMANDS = {
+  "go+": { requiresValueOne: true, setsTo: true },
+  "on": { requiresPositive: true, setsTo: true },
+  "fadermaster": { usesArgs2: true, setsToValue: true },
+  "fadertemp": { usesArgs2: true, setsToValue: true },
+  ">>>": { requiresValueOne: true, setsTo: true },
+  "<<<": { requiresValueOne: true, setsTo: true },
+  "goto": { requiresPositive: true, setsTo: true },
+  "off": { requiresPositive: true, setsTo: false }
+};
+
+// Commands that return to the original running state
+var TEMP_MODIFIERS = {
+  "temp": "positive",
+  "flash": "positive",
+  "black": "negative",
+  "swap": "negative" // MA3 actually spells it this way
+};
+
+var FADER_COMMANDS = {
+  "fadermaster": true,
+  "fadertemp": true
+};
+
+// Helper function to create sequence container
+function createSequenceContainer(sequence) {
+  var parent_container = script.getParent().getParent().values.addContainer("Sequences");
+  return parent_container.addContainer(sequence);
+}
+
+// Helper function to get sequence container
+function getSequenceContainer(sequence) {
   var sequence_container = script.getParent().getParent().values.sequences[sequence];
+  return sequence_container;
+}
+
+// Helper function to initialize sequence state
+function initializeSequenceState(sequence) {
+  var existingState = SequenceStateTracker.getRunningState(sequence);
+  if (!existingState) {
+    var newState = {
+      permanent: false,
+      tempPositive: false,
+      tempNegative: false
+    };
+    SequenceStateTracker.setRunningState(sequence, newState);
+    return newState;
+  }
+  return existingState;
+}
+
+// Helper function to get or create Running parameter
+function getRunningParameter(sequence, sequence_container) {
+  var existingParam = SequenceStateTracker.getRunningParam(sequence);
+  if (existingParam === undefined) {
+    var runningParamCreated = sequence_container.addBoolParameter("Running", "Running", false);
+    SequenceStateTracker.setRunningParam(sequence, runningParamCreated);
+    return runningParamCreated;
+  }
+  return existingParam;
+}
+
+// Helper function to parse command value
+function parseCommandValue(commandLower, args) {
+  var valueIndex = FADER_COMMANDS[commandLower] ? 2 : 1;
+  return parseFloat(args[valueIndex]);
+}
+
+// Helper function to process permanent state changes
+function processPermanentStateChange(commandLower, value, sequenceState) {
+  var commandConfig = PERMANENT_COMMANDS[commandLower];
+  if (!commandConfig) return false;
+
+  var newValue = commandConfig.setsTo;
+
+  // Check if we should update based on command requirements
+  if (commandConfig.requiresValueOne && value == 1) {
+    sequenceState.permanent = newValue;
+    return true;
+  }
+
+  if (commandConfig.requiresPositive && value > 0) {
+    sequenceState.permanent = newValue;
+    return true;
+  }
+
+  if (commandConfig.setsToValue !== undefined) {
+    sequenceState.permanent = value > 0;
+    return true;
+  }
+
+  return false;
+}
+
+// Helper function to process temporary modifiers
+function processTemporaryModifier(commandLower, value, sequenceState) {
+  var modifierType = TEMP_MODIFIERS[commandLower];
+  if (!modifierType) return false;
+
+  var isPositive = value > 0;
+  if (modifierType === "positive") {
+    sequenceState.tempPositive = isPositive;
+  } else if (modifierType === "negative") {
+    sequenceState.tempNegative = isPositive;
+  }
+  return true;
+}
+
+// Helper function to calculate final running state
+function calculateFinalRunningState(sequenceState) {
+  // Temporary modifiers take precedence over permanent state
+  if (sequenceState.tempPositive) return true;
+  if (sequenceState.tempNegative) return false;
+  return sequenceState.permanent;
+}
+
+// Helper function to learn new parameters
+function learnNewParameter(sequence_container, sequence, command, args, isFader) {
+  var param;
+  // Create the appropriate parameter type based on command and args
+  if (args.length == 3 && isFader) {
+    // Fader commands: FaderMaster, FaderTemp, etc.
+    param = sequence_container.addFloatParameter(command, command, 0, 0, 1);
+  } else if (args.length == 3) {
+    // Button commands
+    param = sequence_container.addBoolParameter(command, command, 0);
+  } else {
+    // Default to float parameter for other cases
+    param = sequence_container.addFloatParameter(command, command, 0, 0, 1);
+  }
+
+  // Store the parameter globally to deal with timing issues in local.values
+  SequenceStateTracker.setCreatedParameter(sequence, command, param);
+
+  return sequence_container;
+}
+
+// Helper function to process existing parameters
+function processExistingParameters(sequence_container, command, args, isFader, range, sequence) {
+  // Try to get parameter from container first, then from our stored parameters
+  var param = sequence_container[command];
+
+  if (!param) {
+    // Try to get from our stored parameters
+    param = SequenceStateTracker.getCreatedParameter(sequence, command);
+    if (!param) return;
+  }
+
+  if (args.length == 2) {
+    // Simple on/off commands: Off 1, Flash 1
+    param.set(args[1]);
+  } else if (args.length == 3) {
+    if (isFader) {
+      // Fader commands: FaderMaster 1 99.5, FaderSpeed 1 50.0, etc.
+      // For fader commands, the actual value is in args[2]
+      var faderValue = parseAndScaleFaderValue(args[2], range);
+      param.set(faderValue);
+    } else {
+      // Button commands with descriptions: Go+ 1 "s1 1 Cue", On 1 "s1 1 Cue"
+      updateSequenceName(sequence_container, sequence, args[2]);
+      param.set(args[1]);
+    }
+  } else if (args.length >= 4) {
+    // 4+ arg messages (if any exist)
+    updateSequenceName(sequence_container, sequence, args[3]);
+    param.set(parseAndScaleFaderValue(args[2], range));
+  }
+}
+
+function processSequence(sequence, args) {
+  var sequence_container = getSequenceContainer(sequence);
   var range = local.parameters.faderRange.get();
-  var command = args[0].charAt(0).toLowerCase() + args[0].substring(1, args[0].length);
-  var isFader = command.indexOf("fader") == 0;
+  var command = args[0];
+  var commandLower = command.toLowerCase();
+  var isFader = commandLower.indexOf("fader") == 0;
+  var learnEnabled = local.parameters.learnFromOscInput.get();
+
+  // Create container if it doesn't exist and learning is enabled
+  if (!sequence_container && learnEnabled) {
+    sequence_container = createSequenceContainer(sequence);
+  }
+
+  // Exit if no container exists
+  if (!sequence_container) {
+    return;
+  }
 
   // Learn new parameters if enabled
-  if(!sequence_container[command] && local.parameters.learnFromOscInput.get()) {
-    var parent_container = script.getParent().getParent().values.addContainer("Sequences");
-    sequence_container = parent_container.addContainer(sequence);
-    
-    if (args.length == 3 && isFader) {
-      sequence_container.addFloatParameter(args[0], args[0], 0, 0, 1);
-    } else if (args.length == 3) {
-      sequence_container.addBoolParameter(args[0], args[0], 0);
-    } else {
-      sequence_container.addFloatParameter(args[0], args[0], 0, 0, 1);
-    }
+  if(!sequence_container[command] && learnEnabled) {
+    learnNewParameter(sequence_container, sequence, command, args, isFader);
+  }
+
+  // Initialize sequence state and get Running parameter
+  var sequenceState = initializeSequenceState(sequence);
+  var runningParam = getRunningParameter(sequence, sequence_container);
+
+  // Process running state based on command
+  var value = parseCommandValue(commandLower, args);
+
+  // Handle permanent state changes
+  processPermanentStateChange(commandLower, value, sequenceState);
+
+  // Handle temporary modifiers
+  processTemporaryModifier(commandLower, value, sequenceState);
+
+  // Calculate and update final running state
+  var finalRunningState = calculateFinalRunningState(sequenceState);
+  if (runningParam && typeof runningParam.set === 'function') {
+    runningParam.set(finalRunningState);
   }
 
   // Process existing parameters
-  if(sequence_container[command]) {
-    if (args.length == 2) {
-      // Simple on/off commands: Off 1, Flash 1
-      sequence_container[command].set(args[1]);
-    }
-    else if (args.length == 3) {
-      if (isFader) {
-        // Fader commands: FaderMaster 1 99.5, FaderSpeed 1 50.0, etc.
-        var value = parseFloat(args[2]);
-        if (value === value) { // Check if not NaN
-          sequence_container[command].set(value / range);
-        }
-      } else {
-        // Button commands with descriptions: Go+ 1 "s1 1 Cue", On 1 "s1 1 Cue"
-        sequence_container.setName(sequence + " | " + args[2], sequence);
-        sequence_container[command].set(args[1]);
-      }
-    }
-    else {
-      // 4+ arg messages (if any exist)
-      sequence_container.setName(sequence + " | " + args[3], sequence);
-      var value = parseFloat(args[2]);
-      if (value === value) { // Check if not NaN
-        sequence_container[command].set(value / range);
-      } else {
-        sequence_container[command].set(args[2]);
-      }
-    }
-  }
+  processExistingParameters(sequence_container, command, args, isFader, range, sequence);
 }


### PR DESCRIPTION
1. Update inbound OSC addresses to be compatible with MA3 >= 2.2.
2. More robust parsing of inbound OSC commands. Properly handles OSC commands of different parameter lengths (e.g. fader positions, _Go+_ down/up , etc.), ensuring their values are are recorded in the plugin's sequence container properties.
3. Tracking of sequence running state (i.e. whether it's on or off). If a sequence container is present in the plugin's values, a _Running_ boolean will be added. The plugin will follow and track various events (_Go+_, _Temp_, _Flash_, _Black_, _Swop_, _Off_, non-zero fader positions, and so on....) and set the _Running_ to `true` or `false`. This allows easy mapping, for example, to status LEDs on a controller without needing to do a lot of redundant mapping and triggering inside of Chataigne states machines.