### PR TITLE
Encoder output rounded to 2 decimals

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # grandMA3-Chataigne-Module
 
-A Chataigne module to control grandMA3 via OSC
+A Chataigne module to control grandMA3 via OSC, modded to round encoder output to 2 decimals, as MA3 sometimes losts values with 3 or more decimals. Fader output is untouched (on testing)
 
 ## Purpose
 

--- a/grandMA3.js
+++ b/grandMA3.js
@@ -121,18 +121,6 @@ function syncExecutors(list) {
   }
 }
 
-/*function turnExecutorEncoder(page, executor, offset, multiplicator) {
-  executor = executor + offset;
-  if(page == 0)
-  {
-    local.send("/Encoder" + executor + "/", multiplicator);
-  }
-  else
-  {
-    local.send("/Page" + page + "/Encoder" + executor + "/", multiplicator);
-  }
-}*/
-
 function turnExecutorEncoder(page, executor, offset, multiplicator) {
   var cleanMultiplicator = Math.round(multiplicator * 100) / 100;
   executor = executor + offset;
@@ -177,11 +165,6 @@ function moveSpeedMasterBpmFader(speedMaster, value) {
   var range = local.parameters.faderRange.get();
   local.send("/14.13.3." + speedMaster, "FaderMaster", 1, Math.pow(value, 0.5243838)/0.17118);
 }
-
-/*function turnEncoder(encoder, multiplicator, value) {
-  script.log("Attribute " + encoder + " at + " + value*multiplicator);
-  local.send("/cmd", "Attribute " + encoder + " at + " + value*multiplicator);
-}*/
 
 function turnEncoder(encoder, multiplicator, value) {
   var cleanvalue = Math.round((value * multiplicator) * 100) / 100;

--- a/grandMA3.js
+++ b/grandMA3.js
@@ -121,7 +121,7 @@ function syncExecutors(list) {
   }
 }
 
-function turnExecutorEncoder(page, executor, offset, multiplicator) {
+/*function turnExecutorEncoder(page, executor, offset, multiplicator) {
   executor = executor + offset;
   if(page == 0)
   {
@@ -130,6 +130,19 @@ function turnExecutorEncoder(page, executor, offset, multiplicator) {
   else
   {
     local.send("/Page" + page + "/Encoder" + executor + "/", multiplicator);
+  }
+}*/
+
+function turnExecutorEncoder(page, executor, offset, multiplicator) {
+  var cleanMultiplicator = Math.round(multiplicator * 100) / 100;
+  executor = executor + offset;
+  if(page == 0)
+  {
+    local.send("/Encoder" + executor + "/", cleanMultiplicator);
+  }
+  else
+  {
+    local.send("/Page" + page + "/Encoder" + executor + "/", cleanMultiplicator);
   }
 }
 
@@ -165,9 +178,15 @@ function moveSpeedMasterBpmFader(speedMaster, value) {
   local.send("/14.13.3." + speedMaster, "FaderMaster", 1, Math.pow(value, 0.5243838)/0.17118);
 }
 
-function turnEncoder(encoder, multiplicator, value) {
+/*function turnEncoder(encoder, multiplicator, value) {
   script.log("Attribute " + encoder + " at + " + value*multiplicator);
   local.send("/cmd", "Attribute " + encoder + " at + " + value*multiplicator);
+}*/
+
+function turnEncoder(encoder, multiplicator, value) {
+  var cleanvalue = Math.round((value * multiplicator) * 100) / 100;
+  script.log("Attribute " + encoder + " at + " + cleanvalue);
+  local.send("/cmd", "Attribute " + encoder + " at + " + cleanvalue);
 }
 
 function setProgrammerColor(color, layer) {


### PR DESCRIPTION
I've detected that MA3 sometimes doesn't read floats with many decimals. I rounded to 2, as I think is enough precission to most parameters